### PR TITLE
add capability to match all routes for browser-sync

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -15,6 +15,7 @@
     "browserify": "^12.0.1",
     "coffee-script": "^1.10.0",
     "coffeeify": "^1.2.0",
+    "connect-history-api-fallback": "^1.3.0",
     "ecstatic": "^1.3.1",
     "gulp": "^3.9.0",
     "gulp-coffee": "^2.3.1",

--- a/app/templates/gulpfile.coffee
+++ b/app/templates/gulpfile.coffee
@@ -13,6 +13,13 @@ browserify      = require 'browserify'
 
 production      = process.env.NODE_ENV is 'production'
 browserSync     = require('browser-sync').create()
+
+# to make browser-sync catch all the routes and redirect them to index.html,
+# kind of SPA mode.
+# see:
+# https://github.com/BrowserSync/browser-sync/issues/204#issuecomment-60410751
+historyFallback = require('connect-history-api-fallback')
+
 globalBundler   = null
 
 paths           =
@@ -92,10 +99,11 @@ gulp.task 'styles', ->
 gulp.task 'server', [ 'compile-scripts' ], ->
 
   browserSync.init
-    notify    : no
-    port      : 9000
-    server    :
-      baseDir : './dist'
+    notify       : no
+    port         : 9000
+    server       :
+      baseDir    : './dist'
+      middleware : [ historyFallback() ]
 
 
 gulp.task 'entry-point', ->


### PR DESCRIPTION
`browser-sync`, when not configured, only matches the `/` route and loads `index.html` for that route. Others gets `404 Not Found`. This is not ideal for SPAs.

see relevant discussion: https://github.com/BrowserSync/browser-sync/issues/204#issuecomment-60410751